### PR TITLE
INCLUDE INFERENCE

### DIFF
--- a/utils/person.py
+++ b/utils/person.py
@@ -33,8 +33,11 @@ class Person:
         if path_txt is None:
             self.keypoints = self.get_keypoints(heatmap, offsets)
             self.keypoints.append(self._infer_neck())
+            self.threshold = threshold
             # self.keypoints.append(self._infer_hip())
             self.pose = self.infer_pose(self.keypoints) # This is useless for now TODO:CHANGE
+
+            self.inferred_points = [list(range(19))]
         else:
             self.keypoints = self.skeleton_from_txt(path_txt)
         # LIMBS
@@ -162,13 +165,40 @@ class Person:
         else:
             return 0
 
+    def infer_lc_keypoints(self, prev_person):
+        """This function will be used when creating the frame groups.
+        It takes the Person of the previous frame and uses its keypoits
+        to infer the keypoints of "self".
+        If the keypoint has low confidence, the position of the keypoint
+        relative to the neck is used in the current person
 
-    def infer_point(self, index, neck_prev, kp_prev):
+        
+        Args:
+            prev_person (Person): The person from the current frame
+        """
+        [self.infer_point(index, prev_person) for index, kp in enumerate(self.keypoints)\
+            if self.keypoints[index].confidence < self.threshold and index in self.inferred_points]
+        self.get_height()
+        #for index, kp in enumerate(self.keypoints):
+        #    if kp.confidence < self.threshold:
+        #        self.infer_point(index, prev_person)
+        
+
+    def infer_point(self, index, prev_person):
+        """Use the position of the neck and the same keypoint from the previous frame to infer this one.
+        Same confidence is applied
+
+        Args:
+            index (int): Index of the keypoint to infer
+            prev_person (Person): Person from the previous frame
+        """
         # Use the position of the neck and the same keypoint from the previous frame to infer this one. Same confidence
-        # is appliedhttps://medium.com/@aaditya.chhabra/virtualenv-with-virtualenvwrapper-on-ubuntu-34850ab9e765
-        xi = self.keypoints[17].x + kp_prev.x - neck_prev.x
-        yi = self.keypoints[17].y + kp_prev.y - neck_prev.y
-        self.keypoints[index] = KeyPoint(index, (xi, yi), kp_prev.confidence)
+        # is applied
+        
+        if self.keypoints[index].confidence < self.threshold:
+            xi = self.keypoints[17].x + prev_person.keypoints[index].x - prev_person.keypoints[17].x
+            yi = self.keypoints[17].y + prev_person.keypoints[index].y - prev_person.keypoints[17].y
+            self.keypoints[index] = KeyPoint(index, (xi, yi), prev_person.keypoints[index].confidence)
 
     def get_keypoints_array(self):
         return np.array([(kp.x, kp.y) for kp in self.keypoints])
@@ -176,7 +206,7 @@ class Person:
     def low_confidence_keypoints(self):
         return np.array([kp.index for kp in self.keypoints if kp.confidence > self.threshold])
 
-    def is_valid(self):
+    def is_valid_first(self):
         """This function determines if the frame should be considered for training.
         Before it was embedded inside the pipeline of DataProcessor. Now it's a function,
         so conditions can be changed based on performance.
@@ -185,6 +215,10 @@ class Person:
             bool: True if is valid
         """
         return self.H > 0
+    
+    def is_valid_other(self):
+
+        return True
 
 
 class KeyPoint:


### PR DESCRIPTION
In the search of valid frame groups, if a frame is valid as a First
Frame (H>0), the rest of the frames infer the keypoints that have
confidence < threshold.

Modified logic in dataprocessor to take into account the logic
difference between been suitable as a first frame and as a
non first frame.

Increases training lines ~ 300%